### PR TITLE
Test running compiled swig binary with cibuildwheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,11 @@ before-all = [
     "pipx install -f ninja==1.10.2.2",
     "ninja --version",
 ]
+test-command = [
+  "swig -version",
+  "swig -pcreversion",
+  "swig -help",
+]
 
 [tool.cibuildwheel.linux]
 manylinux-x86_64-image = "manylinux1"


### PR DESCRIPTION
Run swig with -version, -pcreversion, and -help as a sanity check that the compiled binary is at least runnable. At some point it would be nice to add an actual test (e.g. running under pytest) to generate an interface for a particular language and verify that something sane looking gets output by swig.