### PR TITLE
Move Python package metadata from setup.py to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ manylinux-i686-image = "manylinux1"
 name = "swig"
 description = "SWIG is a software development tool that connects programs written in C and C++ with a variety of high-level programming languages."
 keywords = ["swig", "build", "c", "c++"]
+license = {text = "https://github.com/swig/swig/blob/master/LICENSE"}
 readme = "README.md"
 classifiers = [
   "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
@@ -40,6 +41,21 @@ dynamic = ["version"]
 
 [project.scripts]
 swig = "swig:swig"
+
+[project.urls]
+Homepage = "https://swig.org/"
+Download = "https://swig.org/download.html"
+"Source Code" = "https://github.com/nightlark/swig-pypi"
+"Bug Tracker" = "https://github.com/nightlark/swig-pypi/issues"
+
+# Should be possible to specify these fields too, except then "shared" data files end up in the wrong subfolder
+# Eventually should try migrating to scikit-build-core and ditching setuptools entirely
+#[tool.setuptools]
+#packages = ["swig"]
+#package-dir = {"" = "src"}
+#
+#[tool.setuptools.package-data]
+#swig = ["data/*"] 
 
 [tool.setuptools_scm]
 write_to = "src/swig/_version.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ Download = "https://swig.org/download.html"
 #package-dir = {"" = "src"}
 #
 #[tool.setuptools.package-data]
-#swig = ["data/*"] 
+#swig = ["data/*"]
 
 [tool.setuptools_scm]
 write_to = "src/swig/_version.py"

--- a/setup.py
+++ b/setup.py
@@ -20,14 +20,7 @@ cmdclass = {"bdist_wheel": genericpy_bdist_wheel}
 
 setup(
     cmdclass=cmdclass,
-    package_dir={"": "src"},
-    packages=["swig"],
     cmake_install_dir="src/swig/data",
-    url="http://www.swig.org/",
-    download_url="http://www.swig.org/download.html",
-    project_urls={
-        "Source Code": "https://github.com/nightlark/swig-pypi",
-        "Bug Tracker": "https://github.com/nightlark/swig-pypi/issues",
-    },
-    license="https://github.com/swig/swig/blob/master/LICENSE",
+    packages=["swig"],
+    package_dir={"": "src"},
 )


### PR DESCRIPTION
Setuptools v69 makes it required to list metadata fields set in `setup.py` under the `dynamic` key in `pyproject.toml`, otherwise it will error. Since those are fixed values anyway, this PR moves setting the metadata fields to pyproject.toml, which should fix the wheel build errors (and #102).