### PR TITLE
Fix minimum bison version, c++11 standard, and Windows powershell related build errors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
         if: runner.os == 'Windows'
 
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.16.2
+        uses: pypa/cibuildwheel@v2.16.5
         env:
           CIBW_ARCHS: "${{ matrix.arch }}"
           CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,8 +135,8 @@ if(NOT BISON_FOUND AND NOT WIN_USE_PREBUILT)
     ExternalProject_add(BISON-bin
       SOURCE_DIR ${BISON_SOURCE_DIR}
       INSTALL_DIR ${BISON_INSTALL_DIR}
-      URL "https://ftp.gnu.org/gnu/bison/bison-3.7.tar.gz"
-      URL_HASH "SHA256=492ad61202de893ca21a99b621d63fa5389da58804ad79d3f226b8d04b803998"
+      URL "https://ftp.gnu.org/gnu/bison/bison-3.8.2.tar.gz"
+      URL_HASH "SHA256=06c9e13bdf7eb24d4ceb6b59205a4f67c2c7e7213119644430fe82fbd14a0abb"
       CONFIGURE_COMMAND <SOURCE_DIR>/configure --prefix=<INSTALL_DIR>
       BUILD_COMMAND make
       BUILD_IN_SOURCE 1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,7 +99,7 @@ if(NOT WIN_USE_PREBUILT)
 endif()
 
 # Bison
-find_package(BISON)
+find_package(BISON 3.5)
 if(NOT BISON_FOUND AND NOT WIN_USE_PREBUILT)
   set(BISON_SOURCE_DIR ${CMAKE_BINARY_DIR}/BISON-bin-src)
   set(BISON_BINARY_DIR ${CMAKE_BINARY_DIR}/BISON-bin-build)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,7 @@ if(NOT WIN_USE_PREBUILT)
       #URL "https://github.com/swig/swig/archive/master.tar.gz"
       CMAKE_CACHE_ARGS
         -DBUILD_TESTING:BOOL=OFF
+        -DCMAKE_CXX_STANDARD_REQUIRED:BOOL=ON
         -DCMAKE_CXX_STANDARD:STRING=11
         -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_INSTALL_PREFIX}
         "-DCMAKE_C_FLAGS:STRING=${_swig_build_flags}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,7 @@ if(NOT WIN_USE_PREBUILT)
       #URL "https://github.com/swig/swig/archive/master.tar.gz"
       CMAKE_CACHE_ARGS
         -DBUILD_TESTING:BOOL=OFF
+        -DCMAKE_CXX_STANDARD:STRING=11
         -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_INSTALL_PREFIX}
         "-DCMAKE_C_FLAGS:STRING=${_swig_build_flags}"
         "-DCMAKE_CXX_FLAGS:STRING=${_swig_build_flags}"


### PR DESCRIPTION
Several things broke, most due to changes in swig, but also a coincidental change to the GHA VM runners for Windows that updated to a new version of Powershell broke cibuildwheel.

* At minimum, Bison version 3.5 is needed to build swig
* Use bison 3.8.2 when building it from source is required (bison 3.7 has build errors with gcc 4.8 on the manylinux1 build images used)
* Use C++11 standard when compiling swig (otherwise, gcc 4.8 doesn't recognize nullptr keyword)
* Tell CMake that the C++11 standard flag is required, because otherwise AppleClang defaults to C++98 😵‍💫
* Use cibuildwheel 2.16.5 (released ~20 hours ago) which fixes Windows powershell version update related build errors

This PR should address all the issues required to complete #111.