### PR TITLE
Use GHA M1 runners for macOS builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,12 +71,11 @@ jobs:
             build: ""
             artifact_suffix: "windows_x86"
             use_qemu: false
-          - os: macos-11
-            arch: "x86_64 universal2 arm64"
+          - os: macos-14
+            arch: "arm64 universal2 x86_64"
             build: ""
             artifact_suffix: "macos"
             use_qemu: false
-
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,10 @@ jobs:
             mingw-w64-${{matrix.mingw_env}}-toolchain
         if: runner.os == 'Windows'
 
+      - name: Install ninja (macOS)
+        run: which ninja || brew install ninja
+        if: runner.os == 'macOS'
+
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.16.5
         env:


### PR DESCRIPTION
This should make the macOS builds finish a bit faster, and enable running tests on the arm64 wheel.

pipx is not included with the new macOS images, and some things aren't quite working with the install path for pipx installed tools not being added to the PATH -- the easiest workaround was adding a step to install ninja using brew. There may be a pair of unneeded cmake and ninja versions installed, but the system installed copies work just as well. Migrating to scikit-build-core eventually (#104) should make the cibuildwheel `before-all` section unnecessary and at least partially clean things up...