### PR TITLE
Add `swig4.0` binary.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dynamic = ["version"]
 
 [project.scripts]
 swig = "swig:swig"
+"swig4.0" = "swig:swig"
 
 [project.urls]
 Homepage = "https://swig.org/"


### PR DESCRIPTION
Some tools (e.g. FindSWIG in CMake) search for a binary named `swig4.0` instead of `swig` (even when the version is actually "4.2.0", for example). This change simply adds a `swig4.0` binary alongside the `swig` binary already installed by this package.

See: https://gitlab.kitware.com/cmake/cmake/-/issues/25566