### PR TITLE
Add support for building Windows on ARM wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,7 @@ jobs:
           msystem: ${{ matrix.msystem }}
           install: >-
             mingw-w64-${{matrix.mingw_env}}-toolchain
-        if: matrix.os == == 'windows-latest'
+        if: matrix.os == 'windows-latest'
 
       - name: Install ninja (macOS)
         run: which ninja || brew install ninja


### PR DESCRIPTION
PR Description:

- The adoption of Windows on ARM (WoA) devices is steadily increasing, yet many Python wheels are still not available for this platform.
- GitHub Actions now offer native CI runners for Windows on ARM devices (windows-11-arm), enabling automated builds and testing.
- Currently, official swig-pypi Python wheels are not provided for Windows ARM64 and thus users/developers were facing difficulties using popular swig-pypi natively.
- This PR introduces support for building swig-pypi wheels on Windows ARM64, improving accessibility for developers and end users on this emerging platform.
- Additionally, I removed deprecated Windows X64 runner and replaced with latest stable runner for Windows x64 builds(Fixes skipping Windows-x64 builds due to deprecated windows runner) 