### PR TITLE
Add manylinux_riscv64 / musllinux_riscv64 / win_arm64 wheels

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
             artifact_suffix: "macos"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0 # ensure history is present for automatic versioning
 
@@ -117,7 +117,7 @@ jobs:
     name: Build source distributions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0 # ensure history is present for automatic versioning
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,7 @@ jobs:
         run: which pipx || brew install pipx
         if: runner.os == 'macOS'
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.1.1
+        uses: pypa/cibuildwheel@v3.1.2
         env:
           CIBW_ARCHS: "${{ matrix.arch }}"
           CIBW_BUILD: "cp39-${{ matrix.build || '' }}*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
             build: "musllinux_"
             artifact_suffix: "musllinux_s390x"
             use_qemu: true
-          - os: windows-2019
+          - os: windows-2022
             arch: "AMD64"
             msystem: "mingw64"
             mingw_env: "x86_64"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,7 +134,7 @@ jobs:
     needs: [build_wheels, build_sdist]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v5
         with:
           path: dist
           merge-multiple: true
@@ -152,7 +152,7 @@ jobs:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
     - name: Download Python package dist artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v5
       with:
         path: dist
         merge-multiple: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,7 @@ jobs:
         run: which pipx || brew install pipx
         if: runner.os == 'macOS'
       - name: Build wheels
-        uses: pypa/cibuildwheel@v3.1.2
+        uses: pypa/cibuildwheel@v3.1.3
         env:
           CIBW_ARCHS: "${{ matrix.arch }}"
           CIBW_BUILD: "cp39-${{ matrix.build || '' }}*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,7 +93,7 @@ jobs:
         run: which pipx || brew install pipx
         if: runner.os == 'macOS'
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.23.2
+        uses: pypa/cibuildwheel@v3.1.1
         env:
           CIBW_ARCHS: "${{ matrix.arch }}"
           CIBW_BUILD: "cp39-${{ matrix.build || '' }}*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,6 +74,9 @@ jobs:
             msystem: "mingw64"
             mingw_env: "x86_64"
             artifact_suffix: "windows_x86_64"
+          - os: windows-11-arm
+            arch: "ARM64"
+            artifact_suffix: "windows_arm64"
           - os: macos-14
             arch: "universal2"
             artifact_suffix: "macos"
@@ -93,7 +96,7 @@ jobs:
           msystem: ${{ matrix.msystem }}
           install: >-
             mingw-w64-${{matrix.mingw_env}}-toolchain
-        if: runner.os == 'Windows'
+        if: runner.os == 'Windows' && runner.arch == 'X64'
 
       - name: Install ninja (macOS)
         run: which ninja || brew install ninja

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,16 @@ jobs:
             build: "musllinux_"
             artifact_suffix: "musllinux_s390x"
             use_qemu: true
+          - os: ubuntu-latest
+            arch: "riscv64"
+            build: "manylinux_"
+            artifact_suffix: "manylinux_riscv64"
+            use_qemu: true
+          - os: ubuntu-latest
+            arch: "riscv64"
+            build: "musllinux_"
+            artifact_suffix: "musllinux_riscv64"
+            use_qemu: true
           - os: windows-2022
             arch: "AMD64"
             msystem: "mingw64"

--- a/.github/workflows/swig-update-autocheck.yml
+++ b/.github/workflows/swig-update-autocheck.yml
@@ -9,7 +9,7 @@ jobs:
   update-dep:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Check and update SWIG version
         id: check-swig
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ ci:
   autoupdate_schedule: weekly
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v5.0.0
+  rev: v6.0.0
   hooks:
   - id: trailing-whitespace
   - id: end-of-file-fixer

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,8 +65,8 @@ if(NOT WIN_USE_PREBUILT)
       SOURCE_DIR ${PCRE2_SOURCE_DIR}
       BINARY_DIR ${PCRE2_BINARY_DIR}
       INSTALL_DIR ${PCRE2_INSTALL_DIR}
-      URL "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.40/pcre2-10.40.zip"
-      URL_HASH "SHA256=b6ee01732f0e41296e60a00ce37fbed1c4955ae7e7625b1fd29a55605c9493b4"
+      URL "https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.45/pcre2-10.45.zip"
+      URL_HASH "SHA256=59c8556fd45e68599897cd5d74efad9c4a43f85e981fe7ac3ac5fd7aa70672ac"
       CMAKE_CACHE_ARGS
         -DCMAKE_BUILD_TYPE:STRING=${default_build_type}
         -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ manylinux-i686-image = "quay.io/pypa/manylinux2010_i686:2022-08-05-4535177"
 manylinux-aarch64-image = "manylinux2014"
 manylinux-ppc64le-image = "manylinux2014"
 manylinux-s390x-image = "manylinux2014"
+manylinux-riscv64-image = "ghcr.io/mayeut/manylinux_2_31:2025.07.25-1"
 
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ wheel.install-dir = "swig/data"
 [tool.cibuildwheel]
 archs = ["auto64", "auto32"]
 build = "cp39-*"
-enable = ["cpython-experimental-riscv64"]
 test-command = [
   "swig -version",
   "swig -pcreversion",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ wheel.install-dir = "swig/data"
 [tool.cibuildwheel]
 archs = ["auto64", "auto32"]
 build = "cp39-*"
+enable = ["cpython-experimental-riscv64"]
 test-command = [
   "swig -version",
   "swig -pcreversion",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ sdist.include = ["src/swig/_version.py"]
 wheel.install-dir = "swig/data"
 
 [tool.cibuildwheel]
+archs = ["auto64", "auto32"]
 build = "cp39-*"
 test-command = [
   "swig -version",
@@ -39,8 +40,11 @@ test-command = [
 environment.PIP_ONLY_BINARY = ":all:"
 
 [tool.cibuildwheel.linux]
-manylinux-x86_64-image = "manylinux2010"
-manylinux-i686-image = "manylinux2010"
+manylinux-x86_64-image = "quay.io/pypa/manylinux2010_x86_64:2022-08-05-4535177"
+manylinux-i686-image = "quay.io/pypa/manylinux2010_i686:2022-08-05-4535177"
+manylinux-aarch64-image = "manylinux2014"
+manylinux-ppc64le-image = "manylinux2014"
+manylinux-s390x-image = "manylinux2014"
 
 
 [project.scripts]


### PR DESCRIPTION
This PR adds build / publication for manylinux_riscv64 / musllinux_riscv64 / win_arm64  wheels

It includes all PR currently opened if this helps. Otherwise please just close & go for individual PRs.

This required fixing CI (windows-2019 runners are now gone), updating cibuildwheel & PCRE2 (previous version did not build with cmake>=4).
The upgrade of cibuildwheel has been done without changing the manylinux targets (which required changing the defaults).
The image used for riscv64 is based on ubuntu allowing to target manylinux_2_31 and broadening the scope of usability for this build tool rather than restrict it to manylinux_2_39 which is the default in ciibuildwheel (and only image for riscv64 in pypa/manylinux).

fix https://github.com/nightlark/swig-pypi/issues/167
fix https://github.com/nightlark/swig-pypi/issues/166
close #171
close #174
close #175
close #176
close #177 
close #178 